### PR TITLE
Alterando arquivo para o build funcionar

### DIFF
--- a/.github/workflows/treinadleque.yml
+++ b/.github/workflows/treinadleque.yml
@@ -6,14 +6,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: 12.21.0
-      - name: INSTAL AWS CLIENT
-        run: pip install awscli
       - name: INSTALL E BUILD
         run: npm install && npm run build
         env: 


### PR DESCRIPTION
Altere a verão do ubuntu para funcionar e pode remover as linhas 

    "  - name: INSTALL E BUILD
        run: npm install && npm run build"


Por padrão o agent do github actions já vem com uma versão do awscli e não precisa fazer a instalação.


Veja aqui como deve ficar o GitHub Actions:

https://treinacloud.gitbook.io/cloudops/docs